### PR TITLE
Fix README UI screenshots typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ CyberGauntlet is a lightweight CTF-style platform focused on cipher challenges. 
 A quick visual overview of the platform:
 
 ### 🏁 Landing Page
-![Landing UI](Docs/screenshots/landing.png)
+![Landing UI](Docs/screenshots/Landing.png)
 
 ### 🔐 Login / Registration
-![Login UI](Docs/screenshots/login.png)
+![Login UI](Docs/screenshots/Login.png)
 
 ### 🎯 Mission Objectives
-![Objective UI](Docs/screenshots/objective.png)
+![Objective UI](Docs/screenshots/Objective.png)
 
 ---
 ## Features


### PR DESCRIPTION
### What was changed
- Corrected the README UI preview screenshot paths to match the actual repository directory structure.
- Updated links from 
I. `docs/screenshots/landing.png` to `Docs/screenshots/Landing.png`
II. `docs/screenshots/login.png` to `Docs/screenshots/Login.png`
III.  `docs/screenshots/objective.png` to `Docs/screenshots/Objective.png`
       to ensure correct case-sensitive resolution.

### Why this change
- GitHub file paths are case-sensitive.
- The previous paths caused broken image links in the README.
- Fixing this ensures UI preview screenshots render correctly for all users.

### Scope
- Documentation only.
- No changes to application logic or assets.